### PR TITLE
Rename go import paths from cloudfoundry to paketo-buildpacks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@
 .bin
 /bin
 *.tgz
-php-cnb_*
+php-dist_*

--- a/cmd/build/main.go
+++ b/cmd/build/main.go
@@ -21,7 +21,7 @@ import (
 	"os"
 
 	"github.com/cloudfoundry/libcfbuildpack/build"
-	"github.com/cloudfoundry/php-dist-cnb/php"
+	"github.com/paketo-buildpacks/php-dist/php"
 )
 
 func main() {

--- a/cmd/detect/main.go
+++ b/cmd/detect/main.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/cloudfoundry/libcfbuildpack/buildpackplan"
 
-	"github.com/cloudfoundry/php-dist-cnb/php"
+	"github.com/paketo-buildpacks/php-dist/php"
 
 	"github.com/buildpack/libbuildpack/buildplan"
 	"github.com/cloudfoundry/libcfbuildpack/detect"

--- a/cmd/detect/main_test.go
+++ b/cmd/detect/main_test.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/cloudfoundry/libcfbuildpack/buildpackplan"
 
-	"github.com/cloudfoundry/php-dist-cnb/php"
+	"github.com/paketo-buildpacks/php-dist/php"
 
 	"github.com/buildpack/libbuildpack/buildplan"
 	"github.com/cloudfoundry/libcfbuildpack/helper"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/cloudfoundry/php-dist-cnb
+module github.com/paketo-buildpacks/php-dist
 
 go 1.12
 


### PR DESCRIPTION
Fixes #3 

Co-authored-by: Daniel Thornton <dthornton@pivotal.io>