### PR TITLE
Fix deprecated version field

### DIFF
--- a/build.go
+++ b/build.go
@@ -44,7 +44,8 @@ func Build(entries EntryResolver,
 
 		entry := entries.Resolve(context.Plan.Entries)
 
-		dependency, err := dependencies.Resolve(filepath.Join(context.CNBPath, "buildpack.toml"), entry.Name, entry.Version, context.Stack)
+		version, _ := entry.Metadata["version"].(string)
+		dependency, err := dependencies.Resolve(filepath.Join(context.CNBPath, "buildpack.toml"), entry.Name, version, context.Stack)
 
 		if err != nil {
 			return packit.BuildResult{}, err

--- a/build_test.go
+++ b/build_test.go
@@ -47,9 +47,9 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 
 		entryResolver = &fakes.EntryResolver{}
 		entryResolver.ResolveCall.Returns.BuildpackPlanEntry = packit.BuildpackPlanEntry{
-			Name:    "php",
-			Version: "7.2.*",
+			Name: "php",
 			Metadata: map[string]interface{}{
+				"version":        "7.2.*",
 				"version-source": "buildpack.yml",
 			},
 		}
@@ -73,13 +73,13 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		planRefinery.BillOfMaterialsCall.Returns.BuildpackPlan = packit.BuildpackPlan{
 			Entries: []packit.BuildpackPlanEntry{
 				{
-					Name:    "php",
-					Version: "7.2.*",
+					Name: "php",
 					Metadata: map[string]interface{}{
-						"name":   "php-dependency-name",
-						"sha256": "php-dependency-sha",
-						"stacks": []string{"some-stack"},
-						"uri":    "php-dependency-uri",
+						"version": "7.2.*",
+						"name":    "php-dependency-name",
+						"sha256":  "php-dependency-sha",
+						"stacks":  []string{"some-stack"},
+						"uri":     "php-dependency-uri",
 					},
 				},
 			},
@@ -112,9 +112,9 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			Plan: packit.BuildpackPlan{
 				Entries: []packit.BuildpackPlanEntry{
 					{
-						Name:    "php",
-						Version: "7.2.*",
+						Name: "php",
 						Metadata: map[string]interface{}{
+							"version":        "7.2.*",
 							"version-source": "buildpack.yml",
 						},
 					},
@@ -128,13 +128,13 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			Plan: packit.BuildpackPlan{
 				Entries: []packit.BuildpackPlanEntry{
 					{
-						Name:    "php",
-						Version: "7.2.*",
+						Name: "php",
 						Metadata: map[string]interface{}{
-							"name":   "php-dependency-name",
-							"sha256": "php-dependency-sha",
-							"stacks": []string{"some-stack"},
-							"uri":    "php-dependency-uri",
+							"version": "7.2.*",
+							"name":    "php-dependency-name",
+							"sha256":  "php-dependency-sha",
+							"stacks":  []string{"some-stack"},
+							"uri":     "php-dependency-uri",
 						},
 					},
 				},
@@ -161,9 +161,9 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 
 		Expect(entryResolver.ResolveCall.Receives.BuildpackPlanEntrySlice).To(Equal([]packit.BuildpackPlanEntry{
 			{
-				Name:    "php",
-				Version: "7.2.*",
+				Name: "php",
 				Metadata: map[string]interface{}{
+					"version":        "7.2.*",
 					"version-source": "buildpack.yml",
 				},
 			},
@@ -196,9 +196,9 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			Expect(err).NotTo(HaveOccurred())
 
 			entryResolver.ResolveCall.Returns.BuildpackPlanEntry = packit.BuildpackPlanEntry{
-				Name:    "php",
-				Version: "7.2.*",
+				Name: "php",
 				Metadata: map[string]interface{}{
+					"version":        "7.2.*",
 					"version-source": "buildpack.yml",
 					"launch":         true,
 					"build":          true,
@@ -208,13 +208,13 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			planRefinery.BillOfMaterialsCall.Returns.BuildpackPlan = packit.BuildpackPlan{
 				Entries: []packit.BuildpackPlanEntry{
 					{
-						Name:    "php",
-						Version: "7.2.*",
+						Name: "php",
 						Metadata: map[string]interface{}{
-							"name":   "php-dependency-name",
-							"sha256": "php-dependency-sha",
-							"stacks": []string{"some-stack"},
-							"uri":    "php-dependency-uri",
+							"version": "7.2.*",
+							"name":    "php-dependency-name",
+							"sha256":  "php-dependency-sha",
+							"stacks":  []string{"some-stack"},
+							"uri":     "php-dependency-uri",
 						},
 					},
 				},
@@ -233,9 +233,9 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 				Plan: packit.BuildpackPlan{
 					Entries: []packit.BuildpackPlanEntry{
 						{
-							Name:    "php",
-							Version: "7.2.*",
+							Name: "php",
 							Metadata: map[string]interface{}{
+								"version":        "7.2.*",
 								"version-source": "buildpack.yml",
 								"launch":         true,
 								"build":          true,
@@ -250,13 +250,13 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 				Plan: packit.BuildpackPlan{
 					Entries: []packit.BuildpackPlanEntry{
 						{
-							Name:    "php",
-							Version: "7.2.*",
+							Name: "php",
 							Metadata: map[string]interface{}{
-								"name":   "php-dependency-name",
-								"sha256": "php-dependency-sha",
-								"stacks": []string{"some-stack"},
-								"uri":    "php-dependency-uri",
+								"version": "7.2.*",
+								"name":    "php-dependency-name",
+								"sha256":  "php-dependency-sha",
+								"stacks":  []string{"some-stack"},
+								"uri":     "php-dependency-uri",
 							},
 						},
 					},
@@ -286,9 +286,9 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 			planRefinery.BillOfMaterialsCall.Returns.BuildpackPlan = packit.BuildpackPlan{
 				Entries: []packit.BuildpackPlanEntry{
 					{
-						Name:    "new-dep",
-						Version: "some-version",
+						Name: "new-dep",
 						Metadata: map[string]interface{}{
+							"version":          "some-version",
 							"some-extra-field": "an-extra-value",
 						},
 					},
@@ -302,9 +302,9 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 				Plan: packit.BuildpackPlan{
 					Entries: []packit.BuildpackPlanEntry{
 						{
-							Name:    "php",
-							Version: "7.2.*",
+							Name: "php",
 							Metadata: map[string]interface{}{
+								"version":        "7.2.*",
 								"version-source": "buildpack.yml",
 							},
 						},
@@ -318,9 +318,9 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 				Plan: packit.BuildpackPlan{
 					Entries: []packit.BuildpackPlanEntry{
 						{
-							Name:    "new-dep",
-							Version: "some-version",
+							Name: "new-dep",
 							Metadata: map[string]interface{}{
+								"version":          "some-version",
 								"some-extra-field": "an-extra-value",
 							},
 						},
@@ -368,9 +368,9 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 				Plan: packit.BuildpackPlan{
 					Entries: []packit.BuildpackPlanEntry{
 						{
-							Name:    "php",
-							Version: "7.2.*",
+							Name: "php",
 							Metadata: map[string]interface{}{
+								"version":        "7.2.*",
 								"version-source": "buildpack.yml",
 							},
 						},
@@ -408,9 +408,9 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 					Plan: packit.BuildpackPlan{
 						Entries: []packit.BuildpackPlanEntry{
 							{
-								Name:    "php",
-								Version: "7.2.*",
+								Name: "php",
 								Metadata: map[string]interface{}{
+									"version":        "7.2.*",
 									"version-source": "buildpack.yml",
 								},
 							},
@@ -433,9 +433,9 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 					Plan: packit.BuildpackPlan{
 						Entries: []packit.BuildpackPlanEntry{
 							{
-								Name:    "php",
-								Version: "7.2.*",
+								Name: "php",
 								Metadata: map[string]interface{}{
+									"version":        "7.2.*",
 									"version-source": "buildpack.yml",
 								},
 							},
@@ -462,9 +462,9 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 					Plan: packit.BuildpackPlan{
 						Entries: []packit.BuildpackPlanEntry{
 							{
-								Name:    "php",
-								Version: "7.2.*",
+								Name: "php",
 								Metadata: map[string]interface{}{
+									"version":        "7.2.*",
 									"version-source": "buildpack.yml",
 								},
 							},

--- a/detect.go
+++ b/detect.go
@@ -12,6 +12,7 @@ type VersionParser interface {
 }
 
 type BuildPlanMetadata struct {
+	Version       string `toml:"version"`
 	VersionSource string `toml:"version-source"`
 }
 
@@ -26,9 +27,9 @@ func Detect(buildpackYMLParser VersionParser) packit.DetectFunc {
 
 		if version != "" {
 			requirements = append(requirements, packit.BuildPlanRequirement{
-				Name:    "php",
-				Version: version,
+				Name: "php",
 				Metadata: BuildPlanMetadata{
+					Version:       version,
 					VersionSource: "buildpack.yml",
 				},
 			})

--- a/detect_test.go
+++ b/detect_test.go
@@ -66,9 +66,9 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 				},
 				Requires: []packit.BuildPlanRequirement{
 					{
-						Name:    "php",
-						Version: "0.2.4",
+						Name: "php",
 						Metadata: phpdist.BuildPlanMetadata{
+							Version:       "0.2.4",
 							VersionSource: "buildpack.yml",
 						},
 					},

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/onsi/gomega v1.10.1
 	github.com/paketo-buildpacks/occam v0.0.17
-	github.com/paketo-buildpacks/packit v0.2.6
+	github.com/paketo-buildpacks/packit v0.2.7
 	github.com/sclevine/spec v1.4.0
 	gopkg.in/yaml.v2 v2.3.0
 )

--- a/go.sum
+++ b/go.sum
@@ -77,12 +77,16 @@ github.com/paketo-buildpacks/packit v0.1.0/go.mod h1:b40wtWWAcgB47+vYGDD9KKhzOtB
 github.com/paketo-buildpacks/packit v0.2.2/go.mod h1:b40wtWWAcgB47+vYGDD9KKhzOtBjI8KPqGxwGvV+XNs=
 github.com/paketo-buildpacks/packit v0.2.6 h1:+GZSjkt+qmTyux98dr5yYM4DFdThug2FojGvGx1y4Go=
 github.com/paketo-buildpacks/packit v0.2.6/go.mod h1:75NgEq9XQGt+6n/VF8hR0wB8rTGeLmRmbTbhhL/zUow=
+github.com/paketo-buildpacks/packit v0.2.7 h1:KYv4MBU4JnTDE3P5udCskjQFbh668Gbxa6Bbe/582Uc=
+github.com/paketo-buildpacks/packit v0.2.7/go.mod h1:DO2CSp/uF+cn+9pk2zE+Y7ZpA99PPi/pBNYc2p4ZRjk=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/sclevine/agouti v3.0.0+incompatible/go.mod h1:b4WX9W9L1sfQKXeJf1mUTLZKJ48R1S7H23Ji7oFO5Bw=
 github.com/sclevine/spec v1.4.0 h1:z/Q9idDcay5m5irkZ28M7PtQM4aOISzOpj4bUPkDee8=
 github.com/sclevine/spec v1.4.0/go.mod h1:LvpgJaFyvQzRvc1kaDs0bulYwzC70PbiYjC4QnFHkOM=
 github.com/ulikunitz/xz v0.5.7 h1:YvTNdFzX6+W5m9msiYg/zpkSURPPtOlzbqYjrFn7Yt4=
 github.com/ulikunitz/xz v0.5.7/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
+github.com/ulikunitz/xz v0.5.8 h1:ERv8V6GKqVi23rgu5cj9pVfVzJbOqAY2Ntl88O6c2nQ=
+github.com/ulikunitz/xz v0.5.8/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=

--- a/log_emitter.go
+++ b/log_emitter.go
@@ -40,7 +40,8 @@ func (e LogEmitter) Candidates(entries []packit.BuildpackPlanEntry) {
 			maxLen = len(versionSource)
 		}
 
-		sources = append(sources, [2]string{versionSource, entry.Version})
+		version, _ := entry.Metadata["version"].(string)
+		sources = append(sources, [2]string{versionSource, version})
 	}
 
 	for _, source := range sources {

--- a/log_emitter_test.go
+++ b/log_emitter_test.go
@@ -38,12 +38,16 @@ func testLogEmitter(t *testing.T, context spec.G, it spec.S) {
 		it("logs the candidate entries", func() {
 			emitter.Candidates([]packit.BuildpackPlanEntry{
 				{
-					Version: "some-version",
 					Metadata: map[string]interface{}{
+						"version":        "some-version",
 						"version-source": "some-source",
 					},
 				},
-				{Version: "other-version"},
+				{
+					Metadata: map[string]interface{}{
+						"version": "other-version",
+					},
+				},
 			})
 			Expect(buffer.String()).To(Equal(`    Candidate version sources (in priority order):
       some-source -> "some-version"

--- a/plan_entry_resolver_test.go
+++ b/plan_entry_resolver_test.go
@@ -28,42 +28,44 @@ func testPlanEntryResolver(t *testing.T, context spec.G, it spec.S) {
 		it("resolves the best plan entry", func() {
 			entry := resolver.Resolve([]packit.BuildpackPlanEntry{
 				{
-					Name:    "php",
-					Version: "composer-lock-version",
+					Name: "php",
 					Metadata: map[string]interface{}{
+						"version":        "composer-lock-version",
 						"version-source": "composer.lock",
 					},
 				},
 				{
-					Name:    "php",
-					Version: "composer-json-version",
+					Name: "php",
 					Metadata: map[string]interface{}{
+						"version":        "composer-json-version",
 						"version-source": "composer.json",
 					},
 				},
 				{
-					Name:    "php",
-					Version: "other-version",
+					Name: "php",
+					Metadata: map[string]interface{}{
+						"version": "other-version",
+					},
 				},
 				{
-					Name:    "php",
-					Version: "buildpack-yml-version",
+					Name: "php",
 					Metadata: map[string]interface{}{
+						"version":        "buildpack-yml-version",
 						"version-source": "buildpack.yml",
 					},
 				},
 				{
-					Name:    "php",
-					Version: "default-versions-version",
+					Name: "php",
 					Metadata: map[string]interface{}{
+						"version":        "default-versions-version",
 						"version-source": "default-versions",
 					},
 				},
 			})
 			Expect(entry).To(Equal(packit.BuildpackPlanEntry{
-				Name:    "php",
-				Version: "buildpack-yml-version",
+				Name: "php",
 				Metadata: map[string]interface{}{
+					"version":        "buildpack-yml-version",
 					"version-source": "buildpack.yml",
 				},
 			}))
@@ -81,28 +83,30 @@ func testPlanEntryResolver(t *testing.T, context spec.G, it spec.S) {
 		it("resolves the best plan entry", func() {
 			entry := resolver.Resolve([]packit.BuildpackPlanEntry{
 				{
-					Name:    "php",
-					Version: "other-version",
+					Name: "php",
+					Metadata: map[string]interface{}{
+						"version": "other-version",
+					},
 				},
 				{
-					Name:    "php",
-					Version: "default-versions-version",
+					Name: "php",
 					Metadata: map[string]interface{}{
+						"version":        "default-versions-version",
 						"version-source": "default-versions",
 					},
 				},
 				{
-					Name:    "php",
-					Version: "composer-lock-version",
+					Name: "php",
 					Metadata: map[string]interface{}{
+						"version":        "composer-lock-version",
 						"version-source": "composer.lock",
 					},
 				},
 			})
 			Expect(entry).To(Equal(packit.BuildpackPlanEntry{
-				Name:    "php",
-				Version: "composer-lock-version",
+				Name: "php",
 				Metadata: map[string]interface{}{
+					"version":        "composer-lock-version",
 					"version-source": "composer.lock",
 				},
 			}))
@@ -113,28 +117,30 @@ func testPlanEntryResolver(t *testing.T, context spec.G, it spec.S) {
 		it("resolves the best plan entry", func() {
 			entry := resolver.Resolve([]packit.BuildpackPlanEntry{
 				{
-					Name:    "php",
-					Version: "other-version",
+					Name: "php",
+					Metadata: map[string]interface{}{
+						"version": "other-version",
+					},
 				},
 				{
-					Name:    "php",
-					Version: "default-versions-version",
+					Name: "php",
 					Metadata: map[string]interface{}{
+						"version":        "default-versions-version",
 						"version-source": "default-versions",
 					},
 				},
 				{
-					Name:    "php",
-					Version: "composer-json-version",
+					Name: "php",
 					Metadata: map[string]interface{}{
+						"version":        "composer-json-version",
 						"version-source": "composer.json",
 					},
 				},
 			})
 			Expect(entry).To(Equal(packit.BuildpackPlanEntry{
-				Name:    "php",
-				Version: "composer-json-version",
+				Name: "php",
 				Metadata: map[string]interface{}{
+					"version":        "composer-json-version",
 					"version-source": "composer.json",
 				},
 			}))
@@ -145,32 +151,34 @@ func testPlanEntryResolver(t *testing.T, context spec.G, it spec.S) {
 		it("resolves to either of them", func() {
 			entry := resolver.Resolve([]packit.BuildpackPlanEntry{
 				{
-					Name:    "php",
-					Version: "other-version",
+					Name: "php",
+					Metadata: map[string]interface{}{
+						"version": "other-version",
+					},
 				},
 				{
-					Name:    "php",
-					Version: "default-versions-version",
+					Name: "php",
 					Metadata: map[string]interface{}{
+						"version":        "default-versions-version",
 						"version-source": "default-versions",
 					},
 				},
 				{
-					Name:    "php",
-					Version: "composer-json-version",
+					Name: "php",
 					Metadata: map[string]interface{}{
+						"version":        "composer-json-version",
 						"version-source": "composer.json",
 					},
 				},
 				{
-					Name:    "php",
-					Version: "composer-lock-version",
+					Name: "php",
 					Metadata: map[string]interface{}{
+						"version":        "composer-lock-version",
 						"version-source": "composer.lock",
 					},
 				},
 			})
-			Expect(entry.Version).To(ContainSubstring("composer-"))
+			Expect(entry.Metadata["version"]).To(ContainSubstring("composer-"))
 			Expect(entry.Metadata["version-source"]).To(ContainSubstring("composer."))
 		})
 	})
@@ -179,21 +187,23 @@ func testPlanEntryResolver(t *testing.T, context spec.G, it spec.S) {
 		it("resolves the best plan entry", func() {
 			entry := resolver.Resolve([]packit.BuildpackPlanEntry{
 				{
-					Name:    "php",
-					Version: "other-version",
+					Name: "php",
+					Metadata: map[string]interface{}{
+						"version": "other-version",
+					},
 				},
 				{
-					Name:    "php",
-					Version: "default-versions-version",
+					Name: "php",
 					Metadata: map[string]interface{}{
+						"version":        "default-versions-version",
 						"version-source": "default-versions",
 					},
 				},
 			})
 			Expect(entry).To(Equal(packit.BuildpackPlanEntry{
-				Name:    "php",
-				Version: "default-versions-version",
+				Name: "php",
 				Metadata: map[string]interface{}{
+					"version":        "default-versions-version",
 					"version-source": "default-versions",
 				},
 			}))
@@ -205,16 +215,16 @@ func testPlanEntryResolver(t *testing.T, context spec.G, it spec.S) {
 			it("has all flags", func() {
 				entry := resolver.Resolve([]packit.BuildpackPlanEntry{
 					{
-						Name:    "php",
-						Version: "composer-lock-version",
+						Name: "php",
 						Metadata: map[string]interface{}{
+							"version":        "composer-lock-version",
 							"version-source": "composer.lock",
 						},
 					},
 					{
-						Name:    "php",
-						Version: "default-versions-version",
+						Name: "php",
 						Metadata: map[string]interface{}{
+							"version":        "default-versions-version",
 							"version-source": "default-versions",
 							"build":          true,
 							"launch":         true,
@@ -222,9 +232,9 @@ func testPlanEntryResolver(t *testing.T, context spec.G, it spec.S) {
 					},
 				})
 				Expect(entry).To(Equal(packit.BuildpackPlanEntry{
-					Name:    "php",
-					Version: "composer-lock-version",
+					Name: "php",
 					Metadata: map[string]interface{}{
+						"version":        "composer-lock-version",
 						"version-source": "composer.lock",
 						"build":          true,
 						"launch":         true,
@@ -238,14 +248,17 @@ func testPlanEntryResolver(t *testing.T, context spec.G, it spec.S) {
 		it("resolves the best plan entry", func() {
 			entry := resolver.Resolve([]packit.BuildpackPlanEntry{
 				{
-					Name:    "php",
-					Version: "other-version",
+					Name: "php",
+					Metadata: map[string]interface{}{
+						"version": "other-version",
+					},
 				},
 			})
 			Expect(entry).To(Equal(packit.BuildpackPlanEntry{
-				Name:     "php",
-				Version:  "other-version",
-				Metadata: map[string]interface{}{},
+				Name: "php",
+				Metadata: map[string]interface{}{
+					"version": "other-version",
+				},
 			}))
 		})
 	})

--- a/plan_refinery.go
+++ b/plan_refinery.go
@@ -15,14 +15,14 @@ func (r PlanRefinery) BillOfMaterials(dependency postal.Dependency) packit.Build
 	return packit.BuildpackPlan{
 		Entries: []packit.BuildpackPlanEntry{
 			{
-				Name:    dependency.ID,
-				Version: dependency.Version,
+				Name: dependency.ID,
 				Metadata: map[string]interface{}{
 					"licenses": []string{},
 					"name":     dependency.Name,
 					"sha256":   dependency.SHA256,
 					"stacks":   dependency.Stacks,
 					"uri":      dependency.URI,
+					"version":  dependency.Version,
 				},
 			},
 		},

--- a/plan_refinery_test.go
+++ b/plan_refinery_test.go
@@ -33,13 +33,13 @@ func testPlanRefinery(t *testing.T, context spec.G, it spec.S) {
 			})
 			Expect(refinedBuildPlan.Entries).To(HaveLen(1))
 			Expect(refinedBuildPlan.Entries[0].Name).To(Equal("some-id"))
-			Expect(refinedBuildPlan.Entries[0].Version).To(Equal("some-version"))
 			Expect(refinedBuildPlan.Entries[0].Metadata).To(Equal(map[string]interface{}{
 				"licenses": []string{},
 				"name":     "some-name",
 				"sha256":   "some-sha",
 				"stacks":   []string{"some-stack"},
 				"uri":      "some-uri",
+				"version":  "some-version",
 			},
 			))
 		})


### PR DESCRIPTION
See packit changes.
Buildplan and buildpackPlan now has version in the
Metadata map

Signed-off-by: Arjun Sreedharan <asreedharan@vmware.com>