### PR TITLE
removes PHP 7.2; sets 7.4 as default version

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -9,29 +9,7 @@ api = "0.2"
   include-files = ["bin/build", "bin/detect", "bin/run", "buildpack.toml"]
   pre-package = "./scripts/build.sh"
   [metadata.default-versions]
-    php = "7.2.*"
-
-  [[metadata.dependencies]]
-    deprecation_date = "2020-11-30T00:00:00Z"
-    id = "php"
-    name = "PHP"
-    sha256 = "22aa01a4a6e80407280b510065a430f7b5ea8aa0169e28251fe195d4964b2114"
-    source = "https://php.net/distributions/php-7.2.33.tar.gz"
-    source_sha256 = "97bb6b88ddfa44f36c4fc84a1a718faef476f61b532d26ea29e3e9f6cd79d839"
-    stacks = ["io.buildpacks.stacks.bionic", "org.cloudfoundry.stacks.cflinuxfs3"]
-    uri = "https://buildpacks.cloudfoundry.org/dependencies/php/php7_7.2.33_linux_x64_cflinuxfs3_22aa01a4.tgz"
-    version = "7.2.33"
-
-  [[metadata.dependencies]]
-    deprecation_date = "2020-11-30T00:00:00Z"
-    id = "php"
-    name = "PHP"
-    sha256 = "c8302e4381dd66d2b9640a7e418cb00ff1986dba57f363e68b59903f97ea4be8"
-    source = "https://php.net/distributions/php-7.2.34.tar.gz"
-    source_sha256 = "8b2777c741e83f188d3ca6d8e98ece7264acafee86787298fae57e05d0dddc78"
-    stacks = ["io.buildpacks.stacks.bionic", "org.cloudfoundry.stacks.cflinuxfs3"]
-    uri = "https://buildpacks.cloudfoundry.org/dependencies/php/php7_7.2.34_linux_x64_cflinuxfs3_c8302e43.tgz"
-    version = "7.2.34"
+    php = "7.4.*"
 
   [[metadata.dependencies]]
     deprecation_date = "2021-12-06T00:00:00Z"
@@ -76,13 +54,6 @@ api = "0.2"
     stacks = ["io.buildpacks.stacks.bionic", "org.cloudfoundry.stacks.cflinuxfs3"]
     uri = "https://buildpacks.cloudfoundry.org/dependencies/php/php7_7.4.13_linux_x64_cflinuxfs3_f42cc9aa.tgz"
     version = "7.4.13"
-
-  [[metadata.dependency_deprecation_dates]]
-    date = 2020-11-30T00:00:00Z
-    link = "http://php.net/supported-versions.php"
-    match = "7.2.\\d+"
-    name = "php"
-    version_line = "7.2.x"
 
   [[metadata.dependency_deprecation_dates]]
     date = 2021-12-06T00:00:00Z

--- a/integration/offline_test.go
+++ b/integration/offline_test.go
@@ -64,7 +64,7 @@ func testOffline(t *testing.T, context spec.G, it spec.S) {
 			Expect(err).NotTo(HaveOccurred(), logs.String())
 
 			Expect(logs.String()).To(ContainSubstring(buildpackInfo.Buildpack.Name))
-			Expect(logs.String()).To(MatchRegexp(`PHP 7\.2\.\d+`))
+			Expect(logs.String()).To(MatchRegexp(`PHP 7\.4\.\d+`))
 			Expect(logs.String()).NotTo(ContainSubstring("Downloading"))
 
 			container, err = docker.Container.Run.WithCommand("php -i && sleep infinity").Execute(image.ID)
@@ -76,7 +76,7 @@ func testOffline(t *testing.T, context spec.G, it spec.S) {
 				return cLogs.String()
 			}).Should(
 				And(
-					MatchRegexp(`PHP Version => 7\.2\.\d+`),
+					MatchRegexp(`PHP Version => 7\.4\.\d+`),
 					ContainSubstring(
 						fmt.Sprintf("PHP_HOME => /layers/%s/php", strings.ReplaceAll(buildpackInfo.Buildpack.ID, "/", "_")),
 					),

--- a/integration/reuse_layer_rebuild_test.go
+++ b/integration/reuse_layer_rebuild_test.go
@@ -136,7 +136,7 @@ func testReusingLayerRebuild(t *testing.T, context spec.G, it spec.S) {
 			Expect(err).NotTo(HaveOccurred())
 
 			err = ioutil.WriteFile(filepath.Join(source, "buildpack.yml"),
-				[]byte(strings.ReplaceAll(string(contents), "7.2.*", "7.3.*")), 0644)
+				[]byte(strings.ReplaceAll(string(contents), "7.4.*", "7.3.*")), 0644)
 			Expect(err).NotTo(HaveOccurred())
 
 			// Second pack build

--- a/integration/simple_app_test.go
+++ b/integration/simple_app_test.go
@@ -67,13 +67,13 @@ func testSimpleApp(t *testing.T, context spec.G, it spec.S) {
 				fmt.Sprintf("%s %s", buildpackInfo.Buildpack.Name, version),
 				"  Resolving PHP version",
 				"    Candidate version sources (in priority order):",
-				"      buildpack.yml -> \"7.2.*\"",
+				"      buildpack.yml -> \"7.4.*\"",
 				"      <unknown>     -> \"\"",
 				"",
-				MatchRegexp(`    Selected PHP version \(using buildpack\.yml\): 7\.2\.\d+`),
+				MatchRegexp(`    Selected PHP version \(using buildpack\.yml\): 7\.4\.\d+`),
 				"",
 				"  Executing build process",
-				MatchRegexp(`    Installing PHP 7\.2\.\d+`),
+				MatchRegexp(`    Installing PHP 7\.4\.\d+`),
 				MatchRegexp(`      Completed in \d+\.\d+`),
 				"",
 				"  Configuring environment",
@@ -93,7 +93,7 @@ func testSimpleApp(t *testing.T, context spec.G, it spec.S) {
 				return cLogs.String()
 			}).Should(
 				And(
-					MatchRegexp(`PHP Version => 7\.2\.\d+`),
+					MatchRegexp(`PHP Version => 7\.4\.\d+`),
 					ContainSubstring(
 						fmt.Sprintf("PHP_HOME => /layers/%s/php", strings.ReplaceAll(buildpackInfo.Buildpack.ID, "/", "_")),
 					),

--- a/integration/testdata/simple_app/buildpack.yml
+++ b/integration/testdata/simple_app/buildpack.yml
@@ -1,3 +1,3 @@
 ---
 php:
-  version: 7.2.*
+  version: 7.4.*


### PR DESCRIPTION
Signed-off-by: Forest Eckhardt <feckhardt@vmware.com>

Thanks for contributing. To speed up the process of reviewing your pull request
please provide us with:

* A short explanation of the proposed change:
Removes php 7.2 from dependencies and makes 7.4 the default
Resolves #129 

* An explanation of the use cases your change enables:

Please confirm the following:
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have added an integration test, if necessary.
