### PR TITLE
Update default version to 8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,9 @@ file that looks like the following:
   # is not specified, the buildpack will provide the default version, which can
   # be seen in the buildpack.toml file.
   # If you wish to request a specific version, the buildpack supports
-  # specifying a semver constraint in the form of "7.*", "7.4.*", or even
-  # "7.4.4".
-  version = "7.4.4"
+  # specifying a semver constraint in the form of "8.*", "8.0.*", or even
+  # "8.0.4".
+  version = "8.0.4"
 
   # The PHP buildpack supports some non-required metadata options.
   [requires.metadata]

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -9,7 +9,7 @@ api = "0.4"
   include-files = ["bin/build", "bin/detect", "bin/run", "buildpack.toml"]
   pre-package = "./scripts/build.sh"
   [metadata.default-versions]
-    php = "7.4.*"
+    php = "8.0.*"
 
   [[metadata.dependencies]]
     cpe = "cpe:2.3:a:php:php:7.3.31:*:*:*:*:*:*:*"
@@ -113,6 +113,3 @@ api = "0.4"
 [[stacks]]
   id = "io.buildpacks.stacks.bionic"
   mixins = ["libargon2-0", "libcurl4", "libedit2", "libgd3", "libmagickwand-6.q16-3", "libonig4", "libxml2", "libyaml-0-2"]
-
-[[stacks]]
-  id = "org.cloudfoundry.stacks.cflinuxfs3"

--- a/integration/offline_test.go
+++ b/integration/offline_test.go
@@ -64,7 +64,7 @@ func testOffline(t *testing.T, context spec.G, it spec.S) {
 			Expect(err).NotTo(HaveOccurred(), logs.String())
 
 			Expect(logs.String()).To(ContainSubstring(buildpackInfo.Buildpack.Name))
-			Expect(logs.String()).To(MatchRegexp(`PHP 7\.4\.\d+`))
+			Expect(logs.String()).To(MatchRegexp(`PHP 8\.0\.\d+`))
 			Expect(logs.String()).NotTo(ContainSubstring("Downloading"))
 
 			container, err = docker.Container.Run.WithCommand("php -i && sleep infinity").Execute(image.ID)
@@ -76,7 +76,7 @@ func testOffline(t *testing.T, context spec.G, it spec.S) {
 				return cLogs.String()
 			}).Should(
 				And(
-					MatchRegexp(`PHP Version => 7\.4\.\d+`),
+					MatchRegexp(`PHP Version => 8\.0\.\d+`),
 					ContainSubstring(
 						fmt.Sprintf("PHP_HOME => /layers/%s/php", strings.ReplaceAll(buildpackInfo.Buildpack.ID, "/", "_")),
 					),

--- a/integration/reuse_layer_rebuild_test.go
+++ b/integration/reuse_layer_rebuild_test.go
@@ -136,7 +136,7 @@ func testReusingLayerRebuild(t *testing.T, context spec.G, it spec.S) {
 			Expect(err).NotTo(HaveOccurred())
 
 			err = ioutil.WriteFile(filepath.Join(source, "buildpack.yml"),
-				[]byte(strings.ReplaceAll(string(contents), "7.4.*", "7.3.*")), 0644)
+				[]byte(strings.ReplaceAll(string(contents), "8.0.*", "7.4.*")), 0644)
 			Expect(err).NotTo(HaveOccurred())
 
 			// Second pack build

--- a/integration/simple_app_test.go
+++ b/integration/simple_app_test.go
@@ -67,13 +67,13 @@ func testSimpleApp(t *testing.T, context spec.G, it spec.S) {
 				fmt.Sprintf("%s %s", buildpackInfo.Buildpack.Name, version),
 				"  Resolving PHP version",
 				"    Candidate version sources (in priority order):",
-				"      buildpack.yml -> \"7.4.*\"",
+				"      buildpack.yml -> \"8.0.*\"",
 				"      <unknown>     -> \"\"",
 				"",
-				MatchRegexp(`    Selected PHP version \(using buildpack\.yml\): 7\.4\.\d+`),
+				MatchRegexp(`    Selected PHP version \(using buildpack\.yml\): 8\.0\.\d+`),
 				"",
 				"  Executing build process",
-				MatchRegexp(`    Installing PHP 7\.4\.\d+`),
+				MatchRegexp(`    Installing PHP 8\.0\.\d+`),
 				MatchRegexp(`      Completed in \d+\.\d+`),
 				"",
 				"  Configuring environment",
@@ -93,7 +93,7 @@ func testSimpleApp(t *testing.T, context spec.G, it spec.S) {
 				return cLogs.String()
 			}).Should(
 				And(
-					MatchRegexp(`PHP Version => 7\.4\.\d+`),
+					MatchRegexp(`PHP Version => 8\.0\.\d+`),
 					ContainSubstring(
 						fmt.Sprintf("PHP_HOME => /layers/%s/php", strings.ReplaceAll(buildpackInfo.Buildpack.ID, "/", "_")),
 					),

--- a/integration/testdata/simple_app/buildpack.yml
+++ b/integration/testdata/simple_app/buildpack.yml
@@ -1,3 +1,3 @@
 ---
 php:
-  version: 7.4.*
+  version: 8.0.*


### PR DESCRIPTION
PHP 7.4 Active Support Ends 28 Nov 2021 See
https://www.php.net/supported-versions.php
The new active LTS version is 8.0

Also remove support for cflinuxfs3 stack.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
