### PR TITLE
Add PHP 8.3 / Remove PHP 8.0

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -173,6 +173,11 @@ api = "0.7"
     id = "php"
     patches = 2
 
+  [[metadata.dependency-constraints]]
+    constraint = "8.3.*"
+    id = "php"
+    patches = 2
+
 [[stacks]]
   id = "io.buildpacks.stacks.bionic"
   mixins = ["libargon2-0", "libcurl4", "libedit2", "libgd3", "libmagickwand-6.q16-3", "libonig4", "libxml2", "libyaml-0-2"]

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -19,34 +19,6 @@ api = "0.7"
     php = "8.1.*"
 
   [[metadata.dependencies]]
-    checksum = "sha256:5b43a503dc539b45e573c2b0ee77e4585ad6a37de02eb46b16597b0428793d8b"
-    cpe = "cpe:2.3:a:php:php:8.0.29:*:*:*:*:*:*:*"
-    deprecation_date = "2023-11-26T00:00:00Z"
-    id = "php"
-    licenses = ["PHP-3.0", "PHP-3.01"]
-    name = "PHP"
-    purl = "pkg:generic/php@8.0.29?checksum=db6ee08df5706365f624cde1cffb20ad6de1effe59d7e886337213a09f2e2684&download_url=https://github.com/php/web-php-distributions/raw/master/php-8.0.29.tar.gz"
-    source = "https://github.com/php/web-php-distributions/raw/master/php-8.0.29.tar.gz"
-    source-checksum = "sha256:db6ee08df5706365f624cde1cffb20ad6de1effe59d7e886337213a09f2e2684"
-    stacks = ["io.buildpacks.stacks.bionic"]
-    uri = "https://artifacts.paketo.io/php/php_8.0.29_linux_x64_bionic_5b43a503.tgz"
-    version = "8.0.29"
-
-  [[metadata.dependencies]]
-    checksum = "sha256:79cff17b4e2357b613f47cb181f0598c78e3765528b0ac4a0db4f1de2e2c9b4f"
-    cpe = "cpe:2.3:a:php:php:8.0.30:*:*:*:*:*:*:*"
-    deprecation_date = "2023-11-26T00:00:00Z"
-    id = "php"
-    licenses = ["PHP-3.0", "PHP-3.01"]
-    name = "PHP"
-    purl = "pkg:generic/php@8.0.30?checksum=449d2048fcb20a314d8c218097c6d1047a9f1c5bb72aa54d5d3eba0a27a4c80c&download_url=https://github.com/php/web-php-distributions/raw/master/php-8.0.30.tar.gz"
-    source = "https://github.com/php/web-php-distributions/raw/master/php-8.0.30.tar.gz"
-    source-checksum = "sha256:449d2048fcb20a314d8c218097c6d1047a9f1c5bb72aa54d5d3eba0a27a4c80c"
-    stacks = ["io.buildpacks.stacks.bionic"]
-    uri = "https://artifacts.paketo.io/php/php_8.0.30_linux_x64_bionic_79cff17b.tgz"
-    version = "8.0.30"
-
-  [[metadata.dependencies]]
     checksum = "sha256:4e417a397de4663772f22aa844171e293d05e8906b558670edfd63155b6bb6b9"
     cpe = "cpe:2.3:a:php:php:8.1.24:*:*:*:*:*:*:*"
     deprecation_date = "2024-11-25T00:00:00Z"
@@ -157,11 +129,6 @@ api = "0.7"
     stacks = ["io.buildpacks.stacks.jammy"]
     uri = "https://artifacts.paketo.io/php/php_8.2.12_linux_x64_jammy_1de9f35f.tgz"
     version = "8.2.12"
-
-  [[metadata.dependency-constraints]]
-    constraint = "8.0.*"
-    id = "php"
-    patches = 2
 
   [[metadata.dependency-constraints]]
     constraint = "8.1.*"

--- a/dependency/actions/compile/entrypoint.sh
+++ b/dependency/actions/compile/entrypoint.sh
@@ -70,12 +70,12 @@ function main() {
   echo "Determining extensions file"
   local extensions_file
 
-  if [[ ${version} == "8.0"* ]]; then
-    extensions_file="extensions-8.0.yml"
-  elif [[ ${version} == "8.1"* ]]; then
+  if [[ ${version} == "8.1"* ]]; then
     extensions_file="extensions-8.1.yml"
   elif [[ ${version} == "8.2"* ]]; then
     extensions_file="extensions-8.2.yml"
+  elif [[ ${version} == "8.3"* ]]; then
+    extensions_file="extensions-8.3.yml"
   else
     echo "No extensions file found for PHP version ${version}"
     exit 1

--- a/dependency/actions/compile/extensions-manifests/extensions-8.3.yml
+++ b/dependency/actions/compile/extensions-manifests/extensions-8.3.yml
@@ -9,49 +9,37 @@ native_modules:
   md5: bd8ce7069ff99a400efd14cf339a727b
   klass: LuaRecipe
 - name: hiredis
-  version: 1.0.2
-  md5: 58e8313188f66ed1be1c220d14a7752e
+  version: 1.1.0
+  md5: 699faede056b6d5aea1c3f41f832e172
   klass: HiredisRecipe
 - name: snmp
   version: nil
   md5: nil
   klass: SnmpRecipe
 - name: librdkafka
-  version: 1.9.2
-  md5: fe9624e905abbf8324b0f6be520d9c24
+  version: 2.0.2
+  md5: c0120dc32acc129bfb4656fe17568da1
   klass: LibRdKafkaRecipe
 - name: libsodium
   version: 1.0.18
   md5: 3ca9ebc13b6b4735acae0a6a4c4f9a95
   klass: LibSodiumRecipe
 extensions:
-- name: tideways_xhprof
-  version: 5.0.4
-  md5: 68b68cd9410e62b8481445e0d89220c0
-  klass: TidewaysXhprofRecipe
-- name: ssh2
-  version: 1.3.1
-  md5: aa29046de73f1036aea66b4a70f6f598
-  klass: PeclRecipe
-- name: rdkafka
-  version: 6.0.3
-  md5: fd10faec0c599e34837a9482d3c6c801
-  klass: PeclRecipe
-- name: imagick
-  version: 3.7.0
-  md5: '0687774a6126467d4e5ede02171e981d'
-  klass: PeclRecipe
-- name: gnupg
-  version: 1.5.1
-  md5: c48f5de2f96ffebe2e18eaefff4917f9
-  klass: PeclRecipe
 - name: apcu
   version: 5.1.22
   md5: 2e1fb1f09725ada616e873c4e4012ff6
   klass: PeclRecipe
 - name: igbinary
-  version: 3.2.7
-  md5: 927f6cff8e74287453fe327d3893aaa3
+  version: 3.2.14
+  md5: eccbabb49090caf8c3c19dc64f16ce87
+  klass: PeclRecipe
+- name: gnupg
+  version: 1.5.1
+  md5: c48f5de2f96ffebe2e18eaefff4917f9
+  klass: PeclRecipe
+- name: imagick
+  version: 3.7.0
+  md5: '0687774a6126467d4e5ede02171e981d'
   klass: PeclRecipe
 - name: LZF
   version: 1.7.0
@@ -62,8 +50,8 @@ extensions:
   md5: 1ab8d517fcfad5624e6fc4de71e24b47
   klass: PeclRecipe
 - name: mongodb
-  version: 1.14.1
-  md5: 6289847be4b34a5c4561317b02b5e254
+  version: 1.15.1
+  md5: 885483aa6a4fa7fbd723daefece974ec
   klass: PeclRecipe
 - name: msgpack
   version: 2.1.2
@@ -73,30 +61,54 @@ extensions:
   version: 2.0.7
   md5: 8ea6eb5ac6de8a4ed399980848c04c0c
   klass: PeclRecipe
+- name: odbc
+  version: nil
+  md5: nil
+  klass: OdbcRecipe
+- name: pdo_odbc
+  version: nil
+  md5: nil
+  klass: PdoOdbcRecipe
 - name: pdo_sqlsrv
   version: 5.10.1
   md5: 7db86f687b7b69326c7931a31e7a49c3
+  klass: PeclRecipe
+- name: rdkafka
+  version: 6.0.3
+  md5: fd10faec0c599e34837a9482d3c6c801
+  klass: PeclRecipe
+- name: redis
+  version: 5.3.7
+  md5: 1ed6793902214cc02467666ba69dd2be
+  klass: RedisPeclRecipe
+- name: ssh2
+  version: 1.3.1
+  md5: aa29046de73f1036aea66b4a70f6f598
   klass: PeclRecipe
 - name: sqlsrv
   version: 5.10.1
   md5: f60a5eb24c1bba21d78cbbef05efe73d
   klass: PeclRecipe
-- name: xdebug
-  version: 3.1.5
-  md5: fe2b85050c8ac6ddba6ae431f5c6dade
+- name: stomp
+  version: 2.0.3
+  md5: 30de4089ae5c17f32617cef35dbe53e5
   klass: PeclRecipe
-- name: yaf
-  version: 3.3.5
-  md5: 128ecf6c84dd71d59c12d826cc51f0c4
+- name: xdebug
+  version: 3.2.0
+  md5: 2884c58679f8a41d08beb42abc156c22
   klass: PeclRecipe
 - name: yaml
   version: 2.2.2
   md5: 22678c1238f2c6848ff7d74b780a8307
   klass: PeclRecipe
-- name: psr
-  version: 1.2.0
-  md5: '07695da8376002babbce528205decf07'
-  klass: PeclRecipe
+- name: memcached
+  version: 3.2.0
+  md5: acc58fea7b7f456408a25ac927846ad0
+  klass: MemcachedPeclRecipe
+- name: sodium
+  version: nil
+  md5: nil
+  klass: SodiumRecipe
 - name: tidy
   version: nil
   md5: nil
@@ -117,52 +129,43 @@ extensions:
   version: nil
   md5: nil
   klass: FakePeclRecipe
-- name: gd
-  version: nil
-  md5: nil
-  klass: Gd74FakePeclRecipe
+- name: amqp
+  version: 1.11.0
+  md5: 3a0638223e320fc21f3b079198c24f12
+  klass: AmqpPeclRecipe
 - name: maxminddb
   version: 1.11.0
   md5: 5feec07108cf7898bd0591ee54b572cd
   klass: MaxMindRecipe
-- name: odbc
-  version: nil
-  md5: nil
-  klass: OdbcRecipe
-- name: pdo_odbc
-  version: nil
-  md5: nil
-  klass: PdoOdbcRecipe
-- name: redis
-  version: 5.3.7
-  md5: 1ed6793902214cc02467666ba69dd2be
-  klass: RedisPeclRecipe
-- name: memcached
-  version: 3.2.0
-  md5: acc58fea7b7f456408a25ac927846ad0
-  klass: MemcachedPeclRecipe
-- name: sodium
-  version: nil
-  md5: nil
-  klass: SodiumRecipe
+- name: psr
+  version: 1.2.0
+  md5: '07695da8376002babbce528205decf07'
+  klass: PeclRecipe
+- name: phalcon
+  version: 5.2.1
+  md5: 9cd7861e2d0c6171c82e5c882a3e1ff4
+  klass: PeclRecipe
 - name: phpiredis
   version: 1.0.1
   md5: '09a9bdb347c70832d3e034655b604064'
   klass: PHPIRedisRecipe
+- name: tideways_xhprof
+  version: 5.0.4
+  md5: 68b68cd9410e62b8481445e0d89220c0
+  klass: TidewaysXhprofRecipe
 - name: solr
-  version: 2.5.1
-  md5: 29fc866198d61bccdbc4c4f53fb7ef06
+  version: 2.6.0
+  md5: ac5e1e1fbf28e0c543a52c533c967634
   klass: PeclRecipe
 - name: oci8
-  version: 3.0.1
-  md5: 641ebceb483fa2d95e79aea99b1350de
+  version: 3.2.1
+  md5: 309190ef3ede2779a617c9375d32ea7a
   klass: OraclePeclRecipe
 - name: pdo_oci
   version: nil
   md5: nil
   klass: OraclePdoRecipe
-- name: amqp
-  version: 1.11.0
-  md5: 3a0638223e320fc21f3b079198c24f12
-  klass: AmqpPeclRecipe
-
+- name: gd
+  version: nil
+  md5: nil
+  klass: Gd74FakePeclRecipe

--- a/integration/reuse_layer_rebuild_test.go
+++ b/integration/reuse_layer_rebuild_test.go
@@ -100,58 +100,53 @@ func testReusingLayerRebuild(t *testing.T, context spec.G, it spec.S) {
 		})
 	})
 
-	// This test is not currently applicable on jammy because currently Jammy support
-	// only applies to versions of PHP 8.1 and above.
-	// This if statement can be removed when we support PHP 8.2
-	if builder.LocalInfo.Stack.ID != "io.buildpacks.stacks.jammy" {
-		context("when an app is rebuilt and there is a change in php version", func() {
-			it("rebuilds the layer", func() {
-				var (
-					err         error
-					logs        fmt.Stringer
-					firstImage  occam.Image
-					secondImage occam.Image
-				)
+	context("when an app is rebuilt and there is a change in php version", func() {
+		it("rebuilds the layer", func() {
+			var (
+				err         error
+				logs        fmt.Stringer
+				firstImage  occam.Image
+				secondImage occam.Image
+			)
 
-				source, err = occam.Source(filepath.Join("testdata", "simple_app"))
-				Expect(err).NotTo(HaveOccurred())
+			source, err = occam.Source(filepath.Join("testdata", "simple_app"))
+			Expect(err).NotTo(HaveOccurred())
 
-				build := pack.WithNoColor().Build.
-					WithPullPolicy("never").
-					WithBuildpacks(
-						phpDistBuildpack,
-						buildPlanBuildpack,
-					).
-					WithEnv(map[string]string{"BP_PHP_VERSION": "8.1.*"})
+			build := pack.WithNoColor().Build.
+				WithPullPolicy("never").
+				WithBuildpacks(
+					phpDistBuildpack,
+					buildPlanBuildpack,
+				).
+				WithEnv(map[string]string{"BP_PHP_VERSION": "8.2.*"})
 
-				firstImage, logs, err = build.Execute(name, source)
-				Expect(err).NotTo(HaveOccurred())
+			firstImage, logs, err = build.Execute(name, source)
+			Expect(err).NotTo(HaveOccurred())
 
-				imageIDs[firstImage.ID] = struct{}{}
+			imageIDs[firstImage.ID] = struct{}{}
 
-				Expect(firstImage.Buildpacks).To(HaveLen(2))
+			Expect(firstImage.Buildpacks).To(HaveLen(2))
 
-				Expect(firstImage.Buildpacks[0].Key).To(Equal(buildpackInfo.Buildpack.ID))
-				Expect(firstImage.Buildpacks[0].Layers).To(HaveKey("php"))
+			Expect(firstImage.Buildpacks[0].Key).To(Equal(buildpackInfo.Buildpack.ID))
+			Expect(firstImage.Buildpacks[0].Layers).To(HaveKey("php"))
 
-				Expect(logs.String()).To(ContainSubstring("  Executing build process"))
+			Expect(logs.String()).To(ContainSubstring("  Executing build process"))
 
-				// Second pack build
-				secondImage, logs, err = build.WithEnv(map[string]string{"BP_PHP_VERSION": "8.0.*"}).Execute(name, source)
-				Expect(err).NotTo(HaveOccurred())
+			// Second pack build
+			secondImage, logs, err = build.WithEnv(map[string]string{"BP_PHP_VERSION": "8.1.*"}).Execute(name, source)
+			Expect(err).NotTo(HaveOccurred())
 
-				imageIDs[secondImage.ID] = struct{}{}
+			imageIDs[secondImage.ID] = struct{}{}
 
-				Expect(secondImage.Buildpacks).To(HaveLen(2))
+			Expect(secondImage.Buildpacks).To(HaveLen(2))
 
-				Expect(secondImage.Buildpacks[0].Key).To(Equal(buildpackInfo.Buildpack.ID))
-				Expect(secondImage.Buildpacks[0].Layers).To(HaveKey("php"))
+			Expect(secondImage.Buildpacks[0].Key).To(Equal(buildpackInfo.Buildpack.ID))
+			Expect(secondImage.Buildpacks[0].Layers).To(HaveKey("php"))
 
-				Expect(logs.String()).To(ContainSubstring("  Executing build process"))
-				Expect(logs.String()).NotTo(ContainSubstring("Reusing cached layer"))
+			Expect(logs.String()).To(ContainSubstring("  Executing build process"))
+			Expect(logs.String()).NotTo(ContainSubstring("Reusing cached layer"))
 
-				Expect(secondImage.Buildpacks[0].Layers["php"].SHA).NotTo(Equal(firstImage.Buildpacks[0].Layers["php"].SHA))
-			})
+			Expect(secondImage.Buildpacks[0].Layers["php"].SHA).NotTo(Equal(firstImage.Buildpacks[0].Layers["php"].SHA))
 		})
-	}
+	})
 }


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->

Remove support for PHP 8.0
Add dependency constraint support for PHP 8.3

PHP 8.0 is EOL as of Nov 25, 2023 (https://www.php.net/supported-versions.php)
PHP 8.3 is live as of Nov 23, 2023


## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
