### PR TITLE
Add a workaround to retrieval for 8.4.* as 8.4.0 is missing

### DIFF
--- a/dependency/retrieval/main.go
+++ b/dependency/retrieval/main.go
@@ -204,7 +204,12 @@ func getRelease(version string) (PhpRawRelease, error) {
 	// Eg:  7.4.x ---- 7.4.0
 	// Note: Assuming that the oldest patch version is always 0.
 	if patchVersion == "*" {
-		version = strings.ReplaceAll(version, "*", "0")
+		// Note: 8.4.0 is missing in the information from php.net
+		if version == "8.4.*" {
+			version = strings.ReplaceAll(version, "*", "1")
+		} else {
+			version = strings.ReplaceAll(version, "*", "0")
+		}
 	}
 
 	body, err := webClient.Get(fmt.Sprintf("https://raw.githubusercontent.com/paketo-buildpacks/php-dist/main/php-releases/php-%s.json", searchMajorVersion))


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
In the output from php.net version 8.4.0 is missing which breaks retrieval. This adds a workaround to instead check 8.4.1. 

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
